### PR TITLE
Add user accounts with persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A modern, responsive CRM dashboard built with Next.js, TypeScript, Tailwind CSS,
 - **Report Generation**: Custom reports with data visualization
 - **Settings Management**: User preferences and account configuration
 - **Dark Mode**: Toggle between light and dark themes with system preference detection
+- **User Accounts**: Register, log in, and manage data linked to your profile
 
 ## 🛠️ Tech Stack
 
@@ -28,6 +29,7 @@ A modern, responsive CRM dashboard built with Next.js, TypeScript, Tailwind CSS,
 - **UI Components**: shadcn/ui
 - **Icons**: Lucide React
 - **State Management**: React hooks
+- **Database**: Lightweight JSON file storage for persistent data
 
 ## 📦 Installation
 
@@ -160,7 +162,7 @@ The dashboard is fully responsive with:
 - [ ] Deal pipeline management
 - [ ] Email integration
 - [ ] Calendar integration
-- [ ] User authentication
+- [x] User authentication
 - [ ] Dark mode support
 - [ ] Real-time updates
 - [ ] API integration

--- a/data/db.json
+++ b/data/db.json
@@ -1,0 +1,5 @@
+{
+  "users": [],
+  "sessions": {},
+  "customers": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
         "@radix-ui/react-tooltip": "^1.2.7",
+        "bcryptjs": "^2.4.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -3231,6 +3232,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/app/api/customers/[id]/route.ts
+++ b/src/app/api/customers/[id]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getUserIdFromSession, getCustomers, saveCustomers } from '@/lib/db'
+
+export async function PUT(req: NextRequest, context: any) {
+  const { params } = context as { params: { id: string } }
+  const token = req.cookies.get('session')?.value
+  const userId = getUserIdFromSession(token)
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const data = await req.json()
+  const customers = getCustomers(userId)
+  const index = customers.findIndex(c => c.id === params.id)
+  if (index === -1) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  customers[index] = { ...customers[index], ...data }
+  saveCustomers(userId, customers)
+  return NextResponse.json(customers[index])
+}
+
+export async function DELETE(req: NextRequest, context: any) {
+  const { params } = context as { params: { id: string } }
+  const token = req.cookies.get('session')?.value
+  const userId = getUserIdFromSession(token)
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const customers = getCustomers(userId)
+  const index = customers.findIndex(c => c.id === params.id)
+  if (index === -1) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  const [removed] = customers.splice(index, 1)
+  saveCustomers(userId, customers)
+  return NextResponse.json(removed)
+}

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getUserIdFromSession, getCustomers, saveCustomers } from '@/lib/db'
+import { randomUUID } from 'crypto'
+
+export async function GET(req: NextRequest) {
+  const token = req.cookies.get('session')?.value
+  const userId = getUserIdFromSession(token)
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  return NextResponse.json(getCustomers(userId))
+}
+
+export async function POST(req: NextRequest) {
+  const token = req.cookies.get('session')?.value
+  const userId = getUserIdFromSession(token)
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const data = await req.json()
+  const customers = getCustomers(userId)
+  const customer = {
+    id: randomUUID(),
+    name: data.name,
+    email: data.email,
+    phone: data.phone,
+    company: data.company,
+    website: data.website,
+    status: data.status ?? 'active',
+    value: data.value ?? 0,
+    lastContact: new Date().toISOString().split('T')[0],
+    avatar: data.avatar,
+  }
+  customers.push(customer)
+  saveCustomers(userId, customers)
+  return NextResponse.json(customer)
+}

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import bcrypt from 'bcryptjs'
+import { findUserByEmail, createSession } from '@/lib/db'
+
+export async function POST(req: NextRequest) {
+  const { email, password } = await req.json()
+  if (!email || !password) {
+    return NextResponse.json({ error: 'Email and password required' }, { status: 400 })
+  }
+  const user = findUserByEmail(email)
+  if (!user) {
+    return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
+  }
+  const valid = await bcrypt.compare(password, user.passwordHash)
+  if (!valid) {
+    return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
+  }
+  const token = createSession(user.id)
+  const res = NextResponse.json({ id: user.id, email: user.email })
+  res.cookies.set('session', token, { httpOnly: true, path: '/', maxAge: 60 * 60 * 24 * 7 })
+  return res
+}

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { clearSession, getUserIdFromSession } from '@/lib/db'
+
+export function POST(req: NextRequest) {
+  const token = req.cookies.get('session')?.value
+  if (token) clearSession(token)
+  const res = NextResponse.json({ ok: true })
+  res.cookies.set('session', '', { httpOnly: true, path: '/', maxAge: 0 })
+  return res
+}

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getUserIdFromSession, findUserById } from '@/lib/db'
+
+export function GET(req: NextRequest) {
+  const token = req.cookies.get('session')?.value
+  const userId = getUserIdFromSession(token)
+  if (!userId) return NextResponse.json({ user: null })
+  const user = findUserById(userId)
+  if (!user) return NextResponse.json({ user: null })
+  return NextResponse.json({ user: { id: user.id, email: user.email } })
+}

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import bcrypt from 'bcryptjs'
+import { createUser } from '@/lib/db'
+
+export async function POST(req: NextRequest) {
+  const { email, password } = await req.json()
+  if (!email || !password) {
+    return NextResponse.json({ error: 'Email and password required' }, { status: 400 })
+  }
+  try {
+    const hash = await bcrypt.hash(password, 10)
+    const user = createUser(email, hash)
+    return NextResponse.json({ id: user.id, email: user.email })
+  } catch (e: unknown) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : 'Error' }, { status: 400 })
+  }
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const router = useRouter()
+
+  const submit = async () => {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    })
+    if (res.ok) {
+      router.push('/')
+    } else {
+      const data = await res.json()
+      setError(data.error || 'Login failed')
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-4 max-w-sm mx-auto">
+      <h1 className="text-2xl font-bold">Login</h1>
+      {error && <div className="text-red-600">{error}</div>}
+      <Input placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+      <Input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+      <Button onClick={submit}>Login</Button>
+    </div>
+  )
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function RegisterPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const router = useRouter()
+
+  const submit = async () => {
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    })
+    if (res.ok) {
+      router.push('/login')
+    } else {
+      const data = await res.json()
+      setError(data.error || 'Registration failed')
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-4 max-w-sm mx-auto">
+      <h1 className="text-2xl font-bold">Register</h1>
+      {error && <div className="text-red-600">{error}</div>}
+      <Input placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+      <Input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+      <Button onClick={submit}>Register</Button>
+    </div>
+  )
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,97 @@
+import fs from 'fs'
+import path from 'path'
+import { randomUUID } from 'crypto'
+
+export interface User {
+  id: string
+  email: string
+  passwordHash: string
+}
+
+export interface Customer {
+  id: string
+  name: string
+  email: string
+  phone: string
+  company: string
+  website: string
+  status: 'active' | 'pending' | 'inactive'
+  value: number
+  lastContact: string
+  avatar?: string
+}
+
+interface DB {
+  users: User[]
+  sessions: Record<string, string>
+  customers: Record<string, Customer[]>
+}
+
+const dbPath = path.join(process.cwd(), 'data', 'db.json')
+
+function ensureDB(): DB {
+  if (!fs.existsSync(dbPath)) {
+    const init: DB = { users: [], sessions: {}, customers: {} }
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true })
+    fs.writeFileSync(dbPath, JSON.stringify(init, null, 2))
+    return init
+  }
+  const raw = fs.readFileSync(dbPath, 'utf8')
+  return JSON.parse(raw)
+}
+
+function writeDB(db: DB) {
+  fs.writeFileSync(dbPath, JSON.stringify(db, null, 2))
+}
+
+export function createUser(email: string, passwordHash: string) {
+  const db = ensureDB()
+  if (db.users.find(u => u.email === email)) {
+    throw new Error('User already exists')
+  }
+  const user: User = { id: randomUUID(), email, passwordHash }
+  db.users.push(user)
+  writeDB(db)
+  return user
+}
+
+export function findUserByEmail(email: string): User | undefined {
+  const db = ensureDB()
+  return db.users.find(u => u.email === email)
+}
+
+export function findUserById(id: string): User | undefined {
+  const db = ensureDB()
+  return db.users.find(u => u.id === id)
+}
+
+export function createSession(userId: string) {
+  const db = ensureDB()
+  const token = randomUUID()
+  db.sessions[token] = userId
+  writeDB(db)
+  return token
+}
+
+export function getUserIdFromSession(token: string | undefined): string | undefined {
+  if (!token) return undefined
+  const db = ensureDB()
+  return db.sessions[token]
+}
+
+export function clearSession(token: string) {
+  const db = ensureDB()
+  delete db.sessions[token]
+  writeDB(db)
+}
+
+export function getCustomers(userId: string): Customer[] {
+  const db = ensureDB()
+  return db.customers[userId] ?? []
+}
+
+export function saveCustomers(userId: string, customers: Customer[]) {
+  const db = ensureDB()
+  db.customers[userId] = customers
+  writeDB(db)
+}


### PR DESCRIPTION
## Summary
- implement lightweight JSON database with helper functions
- add auth API routes (register, login, logout, current user)
- secure customer API routes with session cookies
- create simple login and register pages
- document new authentication feature

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f0f5700c48320b5785ad3917e6c86