### PR TITLE
Implement simple customer API

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: 'export',
   trailingSlash: true,
   images: {
     unoptimized: true

--- a/src/app/api/customers/[id]/route.ts
+++ b/src/app/api/customers/[id]/route.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextResponse } from 'next/server'
+import { customers, Customer } from '@/data/customers'
+
+export async function PUT(request: Request, { params }: { params: any }) {
+  const id = params.id
+  const index = customers.findIndex(c => c.id === id)
+  if (index === -1) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  const data: Partial<Customer> = await request.json()
+  customers[index] = { ...customers[index], ...data }
+  return NextResponse.json(customers[index])
+}
+
+export async function DELETE(request: Request, { params }: { params: any }) {
+  const id = params.id
+  const index = customers.findIndex(c => c.id === id)
+  if (index === -1) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  const removed = customers.splice(index, 1)[0]
+  return NextResponse.json(removed)
+}

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { customers, Customer } from '@/data/customers'
+
+export async function GET() {
+  return NextResponse.json(customers)
+}
+
+export async function POST(request: Request) {
+  const data: Partial<Customer> = await request.json()
+  const newCustomer: Customer = {
+    id: Date.now().toString(),
+    name: data.name || '',
+    email: data.email || '',
+    phone: data.phone || '',
+    company: data.company || '',
+    website: data.website || '',
+    status: (data.status as Customer['status']) || 'active',
+    value: 0,
+    lastContact: new Date().toISOString().split('T')[0],
+    avatar: data.avatar
+  }
+  customers.push(newCustomer)
+  return NextResponse.json(newCustomer, { status: 201 })
+}

--- a/src/app/customers/page.tsx
+++ b/src/app/customers/page.tsx
@@ -67,59 +67,11 @@ export default function CustomersPage() {
     status: "active" as 'active' | 'pending' | 'inactive'
   })
 
-  // Initialize with sample data
+  // Fetch customers from backend
   useEffect(() => {
-    const sampleCustomers: Customer[] = [
-      {
-        id: "1",
-        name: "Sarah Johnson",
-        email: "sarah.johnson@techcorp.com",
-        phone: "+1 (555) 123-4567",
-        company: "TechCorp Inc.",
-        website: "techcorp.com",
-        status: "active",
-        value: 12000,
-        lastContact: "2024-01-15",
-        avatar: "/avatars/01.png"
-      },
-      {
-        id: "2",
-        name: "Michael Chen",
-        email: "michael.chen@globalsolutions.com",
-        phone: "+1 (555) 234-5678",
-        company: "Global Solutions",
-        website: "globalsolutions.com",
-        status: "pending",
-        value: 8500,
-        lastContact: "2024-01-10",
-        avatar: "/avatars/02.png"
-      },
-      {
-        id: "3",
-        name: "Emily Davis",
-        email: "emily.davis@innovationlabs.com",
-        phone: "+1 (555) 345-6789",
-        company: "Innovation Labs",
-        website: "innovationlabs.com",
-        status: "active",
-        value: 15200,
-        lastContact: "2024-01-12",
-        avatar: "/avatars/03.png"
-      },
-      {
-        id: "4",
-        name: "David Wilson",
-        email: "david.wilson@futuresystems.com",
-        phone: "+1 (555) 456-7890",
-        company: "Future Systems",
-        website: "futuresystems.com",
-        status: "inactive",
-        value: 6800,
-        lastContact: "2024-01-05",
-        avatar: "/avatars/04.png"
-      }
-    ]
-    setCustomers(sampleCustomers)
+    fetch('/api/customers')
+      .then(res => res.json())
+      .then((data: Customer[]) => setCustomers(data))
   }, [])
 
   const filteredCustomers = customers.filter(customer => {
@@ -130,14 +82,16 @@ export default function CustomersPage() {
     return matchesSearch && matchesStatus
   })
 
-  const addCustomer = () => {
-    const customer: Customer = {
-      id: Date.now().toString(),
-      ...newCustomer,
-      value: 0,
-      lastContact: new Date().toISOString().split('T')[0]
+  const addCustomer = async () => {
+    const res = await fetch('/api/customers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(newCustomer)
+    })
+    if (res.ok) {
+      const customer: Customer = await res.json()
+      setCustomers([...customers, customer])
     }
-    setCustomers([...customers, customer])
     setNewCustomer({
       name: "",
       email: "",
@@ -149,14 +103,25 @@ export default function CustomersPage() {
     setIsAddDialogOpen(false)
   }
 
-  const updateCustomer = () => {
+  const updateCustomer = async () => {
     if (!editingCustomer) return
-    setCustomers(customers.map(c => c.id === editingCustomer.id ? editingCustomer : c))
+    const res = await fetch(`/api/customers/${editingCustomer.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(editingCustomer)
+    })
+    if (res.ok) {
+      const updated: Customer = await res.json()
+      setCustomers(customers.map(c => c.id === updated.id ? updated : c))
+    }
     setEditingCustomer(null)
   }
 
-  const deleteCustomer = (id: string) => {
-    setCustomers(customers.filter(c => c.id !== id))
+  const deleteCustomer = async (id: string) => {
+    const res = await fetch(`/api/customers/${id}`, { method: 'DELETE' })
+    if (res.ok) {
+      setCustomers(customers.filter(c => c.id !== id))
+    }
   }
 
   const totalValue = customers.reduce((sum, c) => sum + c.value, 0)

--- a/src/data/customers.ts
+++ b/src/data/customers.ts
@@ -1,0 +1,63 @@
+export interface Customer {
+  id: string
+  name: string
+  email: string
+  phone: string
+  company: string
+  website: string
+  status: 'active' | 'inactive' | 'pending'
+  value: number
+  lastContact: string
+  avatar?: string
+}
+
+export const customers: Customer[] = [
+  {
+    id: "1",
+    name: "Sarah Johnson",
+    email: "sarah.johnson@techcorp.com",
+    phone: "+1 (555) 123-4567",
+    company: "TechCorp Inc.",
+    website: "techcorp.com",
+    status: "active",
+    value: 12000,
+    lastContact: "2024-01-15",
+    avatar: "/avatars/01.png"
+  },
+  {
+    id: "2",
+    name: "Michael Chen",
+    email: "michael.chen@globalsolutions.com",
+    phone: "+1 (555) 234-5678",
+    company: "Global Solutions",
+    website: "globalsolutions.com",
+    status: "pending",
+    value: 8500,
+    lastContact: "2024-01-10",
+    avatar: "/avatars/02.png"
+  },
+  {
+    id: "3",
+    name: "Emily Davis",
+    email: "emily.davis@innovationlabs.com",
+    phone: "+1 (555) 345-6789",
+    company: "Innovation Labs",
+    website: "innovationlabs.com",
+    status: "active",
+    value: 15200,
+    lastContact: "2024-01-12",
+    avatar: "/avatars/03.png"
+  },
+  {
+    id: "4",
+    name: "David Wilson",
+    email: "david.wilson@futuresystems.com",
+    phone: "+1 (555) 456-7890",
+    company: "Future Systems",
+    website: "futuresystems.com",
+    status: "inactive",
+    value: 6800,
+    lastContact: "2024-01-05",
+    avatar: "/avatars/04.png"
+  }
+]


### PR DESCRIPTION
## Summary
- create in-memory customer data module
- add API routes for customers CRUD operations
- load customers from API in Customers page
- switch Next.js config to dynamic output

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f0f283bd4832099ad7ef774649122